### PR TITLE
switch win64par -> win64ext dist on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
       - name: Get and test parallel MODFLOW on Windows
         if: runner.os == 'Windows'
         working-directory: modflow6/.mf6minsim
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           get-modflow --repo modflow6-nightly-build --ostag win64ext :python
           mpiexec -n 1 mf6 -p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         if: runner.os == 'Windows'
         working-directory: modflow6/.mf6minsim
         run: |
-          get-modflow --repo modflow6-nightly-build --ostag win64par :python
+          get-modflow --repo modflow6-nightly-build --ostag win64ext :python
           mpiexec -n 1 mf6 -p
           mpiexec -n 2 mf6 -p
 

--- a/SOFTWARE.md
+++ b/SOFTWARE.md
@@ -169,7 +169,7 @@ On Friday there will be an Advanced Visualization session that will cover use of
 ### 6. Obtaining MODFLOW 6
 =======
 
-We will be using the parallel version of MODFLOW 6 in this class. If you are working on Windows, we will be using the latest nightly-build of the extended version of [MODFLOW 6](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases) in the class. We will also walk through this step during the class. The distribution file for Windows that includes the extended version is called `win64par.zip`.
+We will be using the parallel version of MODFLOW 6 in this class. If you are working on Windows, we will be using the latest nightly-build of the extended version of [MODFLOW 6](https://github.com/MODFLOW-USGS/modflow6-nightly-build/releases) in the class. We will also walk through this step during the class. The distribution file for Windows that includes the extended version is called `win64ext.zip`.
 
 If you are using a MacOS or Linux laptop for the class, then you will need to build the extended version of MODFLOW. We have simplified the build process, which can be completed in just a few minutes. Instructions for building the extended version of MODFLOW 6 are located [here](./build_extended_mf6.md).
 

--- a/exercises-completed/flopy/flopy_getting_started.ipynb
+++ b/exercises-completed/flopy/flopy_getting_started.ipynb
@@ -99,7 +99,7 @@
    "source": [
     "if platform.system() == \"Windows\":\n",
     "    flopy.utils.get_modflow(\n",
-    "        \":python\", repo=\"modflow6-nightly-build\", ostag=\"win64par\", force=True\n",
+    "        \":python\", repo=\"modflow6-nightly-build\", ostag=\"win64ext\", force=True\n",
     "    )"
    ]
   },
@@ -626,9 +626,13 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/exercises/flopy/flopy_getting_started.ipynb
+++ b/exercises/flopy/flopy_getting_started.ipynb
@@ -99,7 +99,7 @@
    "source": [
     "if platform.system() == \"Windows\":\n",
     "    flopy.utils.get_modflow(\n",
-    "        \":python\", repo=\"modflow6-nightly-build\", ostag=\"win64par\", force=True\n",
+    "        \":python\", repo=\"modflow6-nightly-build\", ostag=\"win64ext\", force=True\n",
     "    )"
    ]
   },


### PR DESCRIPTION
Necessary after https://github.com/MODFLOW-USGS/modflow6/pull/2037.

This does not fix CI completely, there are a few more issues which @jmccreight @mjreno and I are working on sorting out